### PR TITLE
Shifting 메커니즘 개선

### DIFF
--- a/gr-rfid/apps/reader.py
+++ b/gr-rfid/apps/reader.py
@@ -56,7 +56,7 @@ class reader_top_block(gr.top_block):
     self.ampl     = 0.55                  # Output signal amplitude (signal power vary for different RFX900 cards)
     self.freq     = 910e6                # Modulation frequency (can be set between 902-920)
     self.rx_gain   = 0                   # RX Gain (gain at receiver)
-    self.tx_gain   = 20                # RFX900 no Tx gain option
+    self.tx_gain   = 50                # RFX900 no Tx gain option
 
 
     self.usrp_address_source = "addr=192.168.255.3,recv_frame_size=256"

--- a/gr-rfid/apps/reader.py
+++ b/gr-rfid/apps/reader.py
@@ -56,7 +56,7 @@ class reader_top_block(gr.top_block):
     self.ampl     = 0.55                  # Output signal amplitude (signal power vary for different RFX900 cards)
     self.freq     = 910e6                # Modulation frequency (can be set between 902-920)
     self.rx_gain   = 0                   # RX Gain (gain at receiver)
-    self.tx_gain   = 20                 # RFX900 no Tx gain option
+    self.tx_gain   = 20                # RFX900 no Tx gain option
 
 
     self.usrp_address_source = "addr=192.168.255.3,recv_frame_size=256"

--- a/gr-rfid/apps/reader.py
+++ b/gr-rfid/apps/reader.py
@@ -56,7 +56,7 @@ class reader_top_block(gr.top_block):
     self.ampl     = 0.55                  # Output signal amplitude (signal power vary for different RFX900 cards)
     self.freq     = 910e6                # Modulation frequency (can be set between 902-920)
     self.rx_gain   = 0                   # RX Gain (gain at receiver)
-    self.tx_gain   = 20                 # RFX900 no Tx gain option
+    self.tx_gain   = 40                 # RFX900 no Tx gain option
 
 
     self.usrp_address_source = "addr=192.168.255.3,recv_frame_size=256"

--- a/gr-rfid/lib/gate_impl.cc
+++ b/gr-rfid/lib/gate_impl.cc
@@ -113,7 +113,7 @@ namespace gr
 
               number_samples_consumed = i-1;
 
-              avg_iq = gr_complex(0.0,0.0);
+              avg_iq = gr_complex(0,0);
               iq_count = 0;
               n_samples = 0;
               amp_pos_threshold = 0;
@@ -128,7 +128,7 @@ namespace gr
             log << "│ Gate seek RN16.." << std::endl;
             reader_state->n_samples_to_ungate = (RN16_BITS + TAG_PREAMBLE_BITS + EXTRA_BITS) * n_samples_TAG_BIT;
             reader_state->gate_status = GATE_SEEK;
-            avg_iq = gr_complex(0.0,0.0);
+            avg_iq = gr_complex(0,0);
             iq_count = 0;
             n_samples = 0;
             amp_pos_threshold = 0;
@@ -140,7 +140,7 @@ namespace gr
             log << "│ Gate seek EPC.." << std::endl;
             reader_state->n_samples_to_ungate = (EPC_BITS + TAG_PREAMBLE_BITS + EXTRA_BITS) * n_samples_TAG_BIT;
             reader_state->gate_status = GATE_SEEK;
-            avg_iq = gr_complex(0.0,0.0);
+            avg_iq = gr_complex(0,0);
             iq_count = 0;
             n_samples = 0;
             amp_pos_threshold = 0;
@@ -165,20 +165,19 @@ namespace gr
               num_pulses = 0;
               max_count = MAX_SEARCH_TRACK;
 
-            }else if(n_samples < T1_LEN){
+            }else if(n_samples < T1_LEN/2){
+
               //add for average iq amplitude
               iq_count++;
               avg_iq += sample;
-            }else if(n_samples == T1_LEN){
+            }else if(n_samples == T1_LEN/2){
               //get average iq amplitude in here
               avg_iq /= iq_count;
               log << "| First AVG amp : " <<avg_iq<<std::endl;
-
               amp_pos_threshold = abs(avg_iq) * AMP_POS_THRESHOLD_RATE;
               amp_neg_threshold = abs(avg_iq) * AMP_NEG_THRESHOLD_RATE;
             }else{// == if(n_samples > T1_LEN)
               //get average iq amplitude in here
-              avg_iq = (avg_iq * (float)FILTER_RATIO) + (sample * (float)(1.0 - FILTER_RATIO));
               amp_pos_threshold = abs(avg_iq) * AMP_POS_THRESHOLD_RATE;
               amp_neg_threshold = abs(avg_iq) * AMP_NEG_THRESHOLD_RATE;
             }

--- a/gr-rfid/lib/gate_impl.cc
+++ b/gr-rfid/lib/gate_impl.cc
@@ -1,22 +1,22 @@
 /* -*- c++ -*- */
 /*
-* Copyright 2015 <Nikos Kargas (nkargas@isc.tuc.gr)>.
-*
-* This is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 3, or (at your option)
-* any later version.
-*
-* This software is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this software; see the file COPYING.  If not, write to
-* the Free Software Foundation, Inc., 51 Franklin Street,
-* Boston, MA 02110-1301, USA.
-*/
+ * Copyright 2015 <Nikos Kargas (nkargas@isc.tuc.gr)>.
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -27,18 +27,15 @@
 #include <sys/time.h>
 #include <stdio.h>
 
-
 #define AMP_LOWBOUND (0.01) //this will let us find the lowest bound
 #define MIN_PULSE (5)
-#define T1_LEN (400)
-#define FILTER_RATIO (0.9)
 
 #define AMP_POS_THRESHOLD_RATE (0.8)
 #define AMP_NEG_THRESHOLD_RATE (0.2)
 
 #define MAX_SEARCH_TRACK (10000)
 #define MAX_SEARCH_READY (8000)
-#define MAX_SEARCH_SEEK  (4000)
+#define MAX_SEARCH_SEEK  (8000)
 
 namespace gr
 {
@@ -46,20 +43,19 @@ namespace gr
   {
     gate::sptr
 
-    gate::make(int sample_rate)
-    {
-      return gnuradio::get_initial_sptr(new gate_impl(sample_rate));
-    }
+      gate::make(int sample_rate)
+      {
+        return gnuradio::get_initial_sptr(new gate_impl(sample_rate));
+      }
 
     /*
-    * The private constructor
-    */
+     * The private constructor
+     */
     gate_impl::gate_impl(int sample_rate)
-    : gr::block("gate",
-    gr::io_signature::make(1, 1, sizeof(gr_complex)),
-    gr::io_signature::make(1, 1, sizeof(gr_complex))),
-
-    n_samples(0), avg_dc(0,0), num_pulses(0)
+      : gr::block("gate",
+          gr::io_signature::make(1, 1, sizeof(gr_complex)),
+          gr::io_signature::make(1, 1, sizeof(gr_complex))),
+      n_samples(0), avg_dc(0,0), num_pulses(0)
     {
       n_samples_T1       = T1_D       * (sample_rate / pow(10,6));
       n_samples_TAG_BIT  = TPRI_D  * (sample_rate / pow(10,6));
@@ -70,193 +66,212 @@ namespace gr
 
     }
 
-    gate_impl::~gate_impl(){}
-
-    void gate_impl::forecast (int noutput_items, gr_vector_int &ninput_items_required)
+    /*
+     * Our virtual destructor.
+     */
+    gate_impl::~gate_impl()
     {
-      ninput_items_required[0] = noutput_items;
     }
 
-    int gate_impl::general_work (int noutput_items, gr_vector_int &ninput_items, gr_vector_const_void_star &input_items, gr_vector_void_star &output_items)
-    {
-      const gr_complex *in = (const gr_complex *) input_items[0];
-      gr_complex *out = (gr_complex *) output_items[0];
-
-
-
-      int number_samples_consumed = ninput_items[0];
-      int written = 0;
-
-
-      log.open(log_file_path, std::ios::app);
-
-      if(reader_state->gate_status != GATE_CLOSED)
+    void
+      gate_impl::forecast (int noutput_items, gr_vector_int &ninput_items_required)
       {
-        for(int i=0 ; i<ninput_items[0] ; i++)
+        ninput_items_required[0] = noutput_items;
+      }
+
+    int
+      gate_impl::general_work (int noutput_items,
+          gr_vector_int &ninput_items,
+          gr_vector_const_void_star &input_items,
+          gr_vector_void_star &output_items)
+      {
+        const gr_complex *in = (const gr_complex *) input_items[0];
+        gr_complex *out = (gr_complex *) output_items[0];
+
+        int number_samples_consumed = ninput_items[0];
+        int written = 0;
+
+
+        log.open(log_file_path, std::ios::app);
+        if(reader_state->gate_status != GATE_CLOSED)
         {
-          gr_complex sample = in[i];          
-
-          if(reader_state->gate_status == GATE_START)
+          for(int i=0 ; i<ninput_items[0] ; i++)
           {
-            if(++n_samples <= 20000) 
+            gr_complex sample = in[i];
+            char data[8];
+            memcpy(data, &sample, 8);
+
+
+            if(reader_state->gate_status == GATE_START)
             {
-              avg_dc += sample;
+              if(++n_samples <= 20000) 
+              {
+                avg_dc += sample;
+              }
+              else if(n_samples > 26000)
+              {
+                avg_dc /= 20000;
+                log << "n_samples_TAG_BIT= " << n_samples_TAG_BIT << std::endl;
+                log << "Average of first 20000 amplitudes= " << avg_dc << std::endl;
+
+                reader_state->gen2_logic_status = SEND_QUERY;
+                reader_state->gate_status = GATE_CLOSED;
+
+                number_samples_consumed = i-1;
+
+                avg_iq = gr_complex(0,0);
+                iq_count = 0;
+                n_samples = 0;
+                amp_pos_threshold = 0;
+                amp_neg_threshold = 0;
+                max_count = MAX_SEARCH_SEEK;
+
+                break;
+              }
             }
-            else if(n_samples > 26000)
+            else if(reader_state->gate_status == GATE_SEEK_RN16)
             {
-              avg_dc /= 20000;
-              log << "n_samples_TAG_BIT= " << n_samples_TAG_BIT << std::endl;
-              log << "Average of first 20000 amplitudes= " << avg_dc << std::endl;
-
-              reader_state->gen2_logic_status = SEND_QUERY;
-              reader_state->gate_status = GATE_CLOSED;
-
-              number_samples_consumed = i-1;
-
+              log << "│ Gate seek RN16.." << std::endl;
+              reader_state->n_samples_to_ungate = (RN16_BITS + TAG_PREAMBLE_BITS + EXTRA_BITS) * n_samples_TAG_BIT;
+              reader_state->gate_status = GATE_SEEK;
               avg_iq = gr_complex(0,0);
               iq_count = 0;
               n_samples = 0;
               amp_pos_threshold = 0;
               amp_neg_threshold = 0;
               max_count = MAX_SEARCH_SEEK;
-
-              break;
+              gate_log_samples.clear();
             }
-          }
-          else if(reader_state->gate_status == GATE_SEEK_RN16)
-          {
-            log << "│ Gate seek RN16.." << std::endl;
-            reader_state->n_samples_to_ungate = (RN16_BITS + TAG_PREAMBLE_BITS + EXTRA_BITS) * n_samples_TAG_BIT;
-            reader_state->gate_status = GATE_SEEK;
-            avg_iq = gr_complex(0,0);
-            iq_count = 0;
-            n_samples = 0;
-            amp_pos_threshold = 0;
-            amp_neg_threshold = 0;
-            max_count = MAX_SEARCH_SEEK;
-          }
-          else if(reader_state->gate_status == GATE_SEEK_EPC)
-          {
-            log << "│ Gate seek EPC.." << std::endl;
-            reader_state->n_samples_to_ungate = (EPC_BITS + TAG_PREAMBLE_BITS + EXTRA_BITS) * n_samples_TAG_BIT;
-            reader_state->gate_status = GATE_SEEK;
-            avg_iq = gr_complex(0,0);
-            iq_count = 0;
-            n_samples = 0;
-            amp_pos_threshold = 0;
-            amp_neg_threshold = 0;
-            max_count = MAX_SEARCH_SEEK;
-          }
-
-          sample -= avg_dc;
-
-          if(reader_state->gate_status == GATE_SEEK)
-          {
-            n_samples++;
-            if(--max_count <= 0){
-              gate_fail();
-              number_samples_consumed = i-1;
-              break;
-            }else if(abs(sample) < amp_neg_threshold){
-              log << "| AVG amp : " <<avg_iq<<std::endl;
-              log << "| FIND first neg amp"<<std::endl;
-              reader_state->gate_status = GATE_TRACK;
-              signal_state = NEG_EDGE;
-              num_pulses = 0;
-              max_count = MAX_SEARCH_TRACK;
-
-            }else if(n_samples < T1_LEN/2){
-
-              //add for average iq amplitude
-              iq_count++;
-              avg_iq += sample;
-            }else if(n_samples == T1_LEN/2){
-              //get average iq amplitude in here
-              avg_iq /= iq_count;
-              log << "| First AVG amp : " <<avg_iq<<std::endl;
-              amp_pos_threshold = abs(avg_iq) * AMP_POS_THRESHOLD_RATE;
-              amp_neg_threshold = abs(avg_iq) * AMP_NEG_THRESHOLD_RATE;
-            }else{// == if(n_samples > T1_LEN)
-              //get average iq amplitude in here
-              amp_pos_threshold = abs(avg_iq) * AMP_POS_THRESHOLD_RATE;
-              amp_neg_threshold = abs(avg_iq) * AMP_NEG_THRESHOLD_RATE;
-            }
-          }
-          else if(reader_state->gate_status == GATE_TRACK)
-          {
-            if(--max_count <= 0)
-            {//log<<std::endl;
-              log<<"GATE TRACK"<<std::endl;
-              log<<"abs value : "<<abs(sample)<<std::endl;
-              if(signal_state == POS_EDGE) log<<"signal_state : POS_EDGE"<<std::endl;
-              else if(signal_state == NEG_EDGE)  log<<"signal_state : NEG_EDGE"<<std::endl;
-              log<<"num pulse : "<<num_pulses<<std::endl;
-              gate_fail();
-              number_samples_consumed = i-1;
-              break;
-            }//og<<sample<<" ";
-
-            if((signal_state == NEG_EDGE) && (abs(sample) > amp_pos_threshold))
+            else if(reader_state->gate_status == GATE_SEEK_EPC)
             {
-              signal_state = POS_EDGE;
+              log << "│ Gate seek EPC.." << std::endl;
+              reader_state->n_samples_to_ungate = (EPC_BITS + TAG_PREAMBLE_BITS + EXTRA_BITS) * n_samples_TAG_BIT;
+              reader_state->gate_status = GATE_SEEK;
+              avg_iq = gr_complex(0,0);
+              iq_count = 0;
+              n_samples = 0;
+              amp_pos_threshold = 0;
+              amp_neg_threshold = 0;
+              max_count = MAX_SEARCH_SEEK;
             }
-            else if((signal_state == POS_EDGE) && (abs(sample) < amp_neg_threshold))
 
+            sample -= avg_dc;
+            gate_log_samples.push_back(sample);
+
+            if(reader_state->gate_status == GATE_SEEK)
             {
-              signal_state = NEG_EDGE;
-              if(++num_pulses > MIN_PULSE)
-              {//log<<std::endl;
-                log << "│ Gate ready!" << std::endl;
-                std::cout << "Command found | ";
-                reader_state->gate_status = GATE_READY;
-                n_samples = 0;
-                max_count = MAX_SEARCH_READY;
+              n_samples++;
+
+              if(--max_count <= 0){
+                gate_fail();
+                number_samples_consumed = i-1;
+                break;
+              }else if(abs(sample) < amp_neg_threshold){
+                log << "| AVG amp : " <<avg_iq<<std::endl;
+                log << "| FIND first neg amp"<<std::endl;
+                reader_state->gate_status = GATE_TRACK;
+                signal_state = NEG_EDGE;
+                num_pulses = 0;
+                max_count = MAX_SEARCH_TRACK;
+
+              }else if(n_samples < (int)(n_samples_T1 * 0.4)){
+
+                //add for average iq amplitude
+                iq_count++;
+                avg_iq += sample;
+              }else if(n_samples == (int)(n_samples_T1 * 0.4)){
+                //get average iq amplitude in here
+                avg_iq /= iq_count;
+                log << "| First AVG amp : " <<avg_iq<<std::endl;
+                amp_pos_threshold = abs(avg_iq) * AMP_POS_THRESHOLD_RATE;
+                amp_neg_threshold = abs(avg_iq) * AMP_NEG_THRESHOLD_RATE;
+
+                std::ofstream iq_logger;
+                iq_logger.open("iq_log.csv", std::ios::app);
+                iq_logger<<reader_state->reader_stats.cur_inventory_round<<", "<<avg_iq.real()<<", "<<avg_iq.imag()<<std::endl;
+                iq_logger.close();
               }
             }
-          }
-          else if(reader_state->gate_status == GATE_READY)
-          {
-            if(--max_count <= 0)
-            {//log<<std::endl;
-              log<<"GATE READY"<<std::endl;
-              gate_fail();
-              number_samples_consumed = i-1;
-              break;
-            }//log<<sample<<" ";
-
-
-            if(abs(sample) < amp_neg_threshold){ 
-              n_samples = 0;
-            }else if(n_samples++ > T1_LEN)
-            {//log<<std::endl;
-              log << "│ Gate open!" << std::endl;
-              log << "├──────────────────────────────────────────────────" << std::endl;
-
-              reader_state->gate_status = GATE_OPEN;
-              n_samples = 0;
-              continue;
-            } 
-          }
-          else if(reader_state->gate_status == GATE_OPEN)
-          {
-            if(++n_samples > reader_state->n_samples_to_ungate)
+            else if(reader_state->gate_status == GATE_TRACK)
             {
-              reader_state->gate_status = GATE_CLOSED;
-              number_samples_consumed = i-1;
+              if(--max_count <= 0)
+              {//log<<std::endl;
+                log<<"GATE TRACK"<<std::endl;
+                log<<"abs value : "<<abs(sample)<<std::endl;
 
-              break;
+                if(signal_state == POS_EDGE) log<<"signal_state : POS_EDGE"<<std::endl;
+                else if(signal_state == NEG_EDGE)  log<<"signal_state : NEG_EDGE"<<std::endl;
+                log<<"num pulse : "<<num_pulses<<std::endl;
+                gate_fail();
+                number_samples_consumed = i-1;
+                break;
+              }//og<<sample<<" ";
+              if((signal_state == NEG_EDGE) && (abs(sample) > amp_pos_threshold))
+              {
+                signal_state = POS_EDGE;
+              }
+              else if((signal_state == POS_EDGE) && (abs(sample) < amp_neg_threshold))
+              {
+                signal_state = NEG_EDGE;
+                if(++num_pulses > MIN_PULSE)
+                {//log<<std::endl;
+                  log << "│ Gate ready!" << std::endl;
+                  std::cout << "Command found | ";
+                  reader_state->gate_status = GATE_READY;
+                  n_samples = 0;
+                  max_count = MAX_SEARCH_READY;
+                }
+              }
             }
+            else if(reader_state->gate_status == GATE_READY)
+            {
+              if(--max_count <= 0)
+              {//log<<std::endl;
+                log<<"GATE READY"<<std::endl;
+                gate_fail();
+                number_samples_consumed = i-1;
+                break;
+              }//log<<sample<<" ";
+              if(signal_state == POS_EDGE){ 
+                if(abs(sample) < amp_neg_threshold){
+                  signal_state = NEG_EDGE;
+                }else if(n_samples++ > (int)n_samples_T1/2)
+                {//log<<std::endl;
+                  log << "│ Gate open! " << n_samples<<", "<<gate_log_samples.size() << std::endl;
+                  log << "├──────────────────────────────────────────────────" << std::endl;
+                  reader_state->gate_status = GATE_OPEN;
+                  written = 0;
+                  n_samples = 0;
+                  continue;
+                }
+              }else if((signal_state == NEG_EDGE) && (abs(sample) > amp_pos_threshold))
+              {
+                n_samples = 0;
+                signal_state = POS_EDGE;
+              }
+            }
+            else if(reader_state->gate_status == GATE_OPEN)
+            {
+              if(++n_samples > reader_state->n_samples_to_ungate)
+              {
+                gateLogSave();          
+      
+                reader_state->gate_status = GATE_CLOSED;
+                number_samples_consumed = i-1;
 
-            out[written++] = sample - avg_iq;
+                break;
+              }
+              out[written++] = sample - avg_iq;
+
+            }
           }
-        }
+        } //end of "gate_status != GATE_CLOSE"
+
+        log.close();
+
+        consume_each(number_samples_consumed);
+        return written;
       }
-
-      log.close();
-
-      consume_each(number_samples_consumed);
-      return written;
-    }
 
     void gate_impl::gate_fail(void)
     {
@@ -265,6 +280,8 @@ namespace gr
       log << "│ Gate search FAIL!" << std::endl;
       std::cout << "Gate FAIL!!";
       reader_state->gate_status = GATE_CLOSED;
+
+      gateLogSave();
 
       reader_state->reader_stats.cur_slot_number++;
       if(reader_state->reader_stats.cur_slot_number > reader_state->reader_stats.max_slot_number)
@@ -288,5 +305,17 @@ namespace gr
 
       log.close();
     }
-  }
-}
+
+    void gate_impl::gateLogSave(void){
+      std::ofstream gate_logger;
+
+      gate_logger.open("gateOpenTracker/"+std::to_string(reader_state->reader_stats.cur_inventory_round), std::ios::out|std::ios::binary);
+      for(int i = 0; i<gate_log_samples.size();i++){
+        gate_logger.write((char*)&gate_log_samples[i], sizeof(gr_complex));
+      }
+
+      gate_log_samples.clear();
+      gate_logger.close();
+    }
+  } // namespace rfid
+} // namespace gr

--- a/gr-rfid/lib/gate_impl.h
+++ b/gr-rfid/lib/gate_impl.h
@@ -37,7 +37,7 @@ namespace gr {
         int n_samples, n_samples_T1, n_samples_TAG_BIT, n_samples_PW;
 
 
-        gr_complex avg_iq = gr_complex(0.0,0.0);
+        gr_complex avg_iq;
         gr_complex avg_dc;
 
         int iq_count = 0;

--- a/gr-rfid/lib/gate_impl.h
+++ b/gr-rfid/lib/gate_impl.h
@@ -26,6 +26,7 @@
 #include "rfid/global_vars.h"
 #include <fstream>
 
+
 namespace gr {
   namespace rfid {
     class gate_impl : public gate
@@ -35,7 +36,6 @@ namespace gr {
         enum SIGNAL_STATE {NEG_EDGE, POS_EDGE};
 
         int n_samples, n_samples_T1, n_samples_TAG_BIT, n_samples_PW;
-
 
         gr_complex avg_iq;
         gr_complex avg_dc;
@@ -47,20 +47,22 @@ namespace gr {
         float amp_pos_threshold = 0;
         float amp_neg_threshold = 0;
 
-
         SIGNAL_STATE signal_state;
 
         std::ofstream log;
-       public:
+        std::vector<gr_complex> gate_log_samples;
+
+        void gateLogSave(void);
+      public:
         gate_impl(int sample_rate);
         ~gate_impl();
 
         void forecast (int noutput_items, gr_vector_int &ninput_items_required);
 
         int general_work(int noutput_items,
-             gr_vector_int &ninput_items,
-             gr_vector_const_void_star &input_items,
-             gr_vector_void_star &output_items);
+            gr_vector_int &ninput_items,
+            gr_vector_const_void_star &input_items,
+            gr_vector_void_star &output_items);
 
         void gate_fail();
     };

--- a/gr-rfid/lib/tag_decoder_class.cc
+++ b/gr-rfid/lib/tag_decoder_class.cc
@@ -13,20 +13,16 @@ namespace gr
     {
       _in = NULL;
       _total_size = 0;
-      _norm_in.clear();
-
       _corr = 0;
+      _complex_corr = std::complex<float>(0.0,0.0);
+
     }
 
     tag_decoder_impl::sample_information::sample_information(gr_complex* __in, int __total_size)
     // mode: 0:RN16, 1:EPC
     {
-      _in = __in;
-      _total_size = __total_size;
-      _norm_in.clear();
-      for(int i=0 ; i<_total_size ; i++)
-        _norm_in.push_back(std::sqrt(std::norm(_in[i])));
-
+      this->_in = __in;
+      this->_total_size = __total_size;
       _corr = 0;
       _complex_corr = std::complex<float>(0.0,0.0);
     }
@@ -55,7 +51,7 @@ namespace gr
 
     float tag_decoder_impl::sample_information::norm_in(int index)
     {
-      return _norm_in[index];
+      return std::abs(_in[index]);
     }
 
     float tag_decoder_impl::sample_information::corr(void)

--- a/gr-rfid/lib/tag_decoder_decoder.cc
+++ b/gr-rfid/lib/tag_decoder_decoder.cc
@@ -126,7 +126,7 @@ namespace gr
         corr_result[1] = mask_correlation(ys, FM0_MASKS[1], FM0_MASKS_LENGTH,idx-SHIFT_SIZE, mask_level);
 
         if(corr_result[0].imag() == 0 ||corr_result[0].real() == 0 ||corr_result[1].real() == 0 ||corr_result[1].imag() == 0){
-          std::cerr << "Zero Error detected (" << corr_result[0].real() <<", "<<corr_result[0].imag()<<"), ("<< corr_result[0].real() <<", "<<corr_result[0].imag()<<"), "<<-SHIFT_SIZE<<" | ";
+          std::cerr << "Zero Error detected (" << corr_result[0].real() <<", "<<corr_result[0].imag()<<"), ("<< corr_result[1].real() <<", "<<corr_result[1].imag()<<"), "<<-SHIFT_SIZE<<" | ";
         }
 
         if(std::abs(corr_result[0]) > std::abs(corr_result[1])){
@@ -145,7 +145,7 @@ namespace gr
           corr_result[1] = mask_shift_one_sample(ys, FM0_MASKS[1], FM0_MASKS_LENGTH, corr_result[1], idx+j, mask_level);
 
           if(corr_result[0].imag() == 0 ||corr_result[0].real() == 0 ||corr_result[1].real() == 0 ||corr_result[1].imag() == 0){
-            std::cerr << "Zero Error detected (" << corr_result[0].real() <<", "<<corr_result[0].imag()<<"), ("<< corr_result[0].real() <<", "<<corr_result[0].imag()<<"), "<<j+1<<" | ";
+            std::cerr << "Zero Error detected (" << corr_result[0].real() <<", "<<corr_result[0].imag()<<"), ("<< corr_result[1].real() <<", "<<corr_result[1].imag()<<"), "<<j+1<<" | ";
           }
 
           //Find the Biggest Correlation value
@@ -191,12 +191,23 @@ namespace gr
         data -= data & 1;
         if(decoded_bits[i] > 0.5){
           data += 1;
-        }
-        //std::cout<<in[i];
+        }        //std::cout<<in[i];
       }
 
       if(data == 0xAAAA)
         correct_bit++;
+      else{
+        data = (data ^ 0xAAAA);
+        int b_c = 0;
+        int data1 = data;
+        for(int i = 0; i<16; i++){
+          if(data1 % 2 == 1)
+            b_c++;
+          data1 /= 2;
+        }
+        std::cout << std::hex<<data<<std::dec<<", "<<b_c<<" | ";
+      }
+
       std::cout<<correct_bit<<" | ";
 
       return decoded_bits;

--- a/gr-rfid/lib/tag_decoder_decoder.cc
+++ b/gr-rfid/lib/tag_decoder_decoder.cc
@@ -78,6 +78,8 @@ namespace gr
       else return -1;
     }
 
+    static int correct = 0;
+
     std::vector<float> tag_decoder_impl::tag_detection(sample_information* ys, int index, int n_expected_bit)
       // This method decodes n_expected_bit of data by using previous methods, and returns the vector of the decoded data.
       // index: start point of "data bit", do not decrease half bit!
@@ -138,6 +140,20 @@ namespace gr
 
       ys->set_corr(max_corr_sum/n_expected_bit);
       ys->set_complex_corr(max_complex_corr_sum/(float)n_expected_bit);
+
+      int data = 0;
+
+      for(int i = 0; i<16; i++){
+        data = data<<1;
+        data -= (data&1);
+        if(decoded_bits[i] == 1)
+          data+=1;
+      }
+
+      if(data == 0xAAAA)
+        correct++;
+
+      std::cout<< correct << " | ";
 
       return decoded_bits;
     }

--- a/gr-rfid/lib/tag_decoder_decoder.cc
+++ b/gr-rfid/lib/tag_decoder_decoder.cc
@@ -4,6 +4,7 @@
 #endif
 
 #include "tag_decoder_impl.h"
+#include <cmath>
 
 #define SHIFT_SIZE 5  // used in tag_detection
 
@@ -43,10 +44,10 @@ namespace gr
       int max_index = 0;
       gr_complex max_stddev = 0.0;
 
-      // compare all samples with sliding
+      // compare all samples with sliding except T1
       for(int i=0 ; i<ys->total_size()-(n_samples_TAG_BIT*(TAG_PREAMBLE_BITS+n_expected_bit)) ; i++)  // i: start point
       {
-        
+
         // calculate correlation value
         if(i==0){
           corr_temp = mask_correlation(ys, TAG_PREAMBLE_MASKS, TAG_PREAMBLE_MASKS_LENGTH, 0 , 1);
@@ -172,33 +173,6 @@ namespace gr
 
       ys->set_corr(max_corr_sum/n_expected_bit);
       ys->set_complex_corr(max_complex_corr_sum/(float)n_expected_bit);
-
-
-      int data = 0;
-      for(int i = 0; i<16; i++){
-        data = data << 1;
-        data -= data & 1;
-        if(decoded_bits[i] > 0.5){
-          data += 1;
-        }        //std::cout<<in[i];
-      }
-
-     if(data == 0xAAAA)
-        correct_bit++;
-      else{
-        data = (data ^ 0xAAAA);
-        int b_c = 0;
-        int data1 = data;
-        for(int i = 0; i<16; i++){
-          if(data1 % 2 == 1)
-            b_c++;
-          data1 /= 2;
-        }
-        std::cout << std::hex<<data<<std::dec<<", "<<b_c<<" | ";
-
-      }
-
-      std::cout<<correct_bit<<" | ";
 
       return decoded_bits;
     }

--- a/gr-rfid/lib/tag_decoder_decoder.cc
+++ b/gr-rfid/lib/tag_decoder_decoder.cc
@@ -30,7 +30,7 @@ namespace gr
     {1, 1, -1, 1, -1, -1, 1, -1, -1, -1, 1, 1};
 
 
-    int tag_decoder_impl::tag_sync(sample_information* ys, int n_expected_bit)
+    int tag_decoder_impl::tag_sync(sample_information* ys)
       // This method searches the preamble and returns the start index of the tag data.
       // If the correlation value exceeds the threshold, it returns the start index of the tag data.
       // Else, it returns -1.
@@ -45,14 +45,14 @@ namespace gr
       gr_complex max_stddev = 0.0;
 
       // compare all samples with sliding except T1
-      for(int i=0 ; i<ys->total_size()-(n_samples_TAG_BIT*(TAG_PREAMBLE_BITS+n_expected_bit)) ; i++)  // i: start point
+      for(int i=0 ; i<ys->total_size()-win_size ; i++)  // i: start point
       {
 
         // calculate correlation value
         if(i==0){
-          corr_temp = mask_correlation(ys, TAG_PREAMBLE_MASKS, TAG_PREAMBLE_MASKS_LENGTH, 0 , 1);
+          corr_temp = mask_correlation(ys, TAG_PREAMBLE_MASKS, TAG_PREAMBLE_MASKS_LENGTH, i , 1);
         }else{
-          corr_temp = mask_shift_one_sample(ys,TAG_PREAMBLE_MASKS, TAG_PREAMBLE_MASKS_LENGTH, corr_temp, i-1, 1);
+          corr_temp = mask_shift_one_sample(ys,TAG_PREAMBLE_MASKS, TAG_PREAMBLE_MASKS_LENGTH, corr_temp, i, 1);
         }
 
         // get max correlation value for ith start point

--- a/gr-rfid/lib/tag_decoder_decoder.cc
+++ b/gr-rfid/lib/tag_decoder_decoder.cc
@@ -7,12 +7,28 @@
 
 #define SHIFT_SIZE 2  // used in tag_detection
 
+#define FM0_MASKS_LENGTH  4
+#define TAG_PREAMBLE_MASKS_LENGTH  12
+
+
 //#define __DEBUG__
 
 namespace gr
 {
   namespace rfid
   {
+
+    const static float FM0_MASKS[2][FM0_MASKS_LENGTH] = { // first, last elements are extra bits. second, third elements are real signal.
+      {1, -1, 1, -1}, {1, -1, -1, 1}, // low level start
+    };
+
+
+    // FM0 encoding preamble sequences
+    // const int TAG_PREAMBLE[] = {1,1,-1,1,-1,-1,1,-1,-1,-1,1,1};
+    const static float TAG_PREAMBLE_MASKS[TAG_PREAMBLE_MASKS_LENGTH] =
+    {1, 1, -1, 1, -1, -1, 1, -1, -1, -1, 1, 1};
+
+
     int tag_decoder_impl::tag_sync(sample_information* ys, int n_expected_bit)
       // This method searches the preamble and returns the start index of the tag data.
       // If the correlation value exceeds the threshold, it returns the start index of the tag data.
@@ -22,6 +38,7 @@ namespace gr
       int win_size = n_samples_TAG_BIT * TAG_PREAMBLE_BITS;
       float threshold = n_samples_TAG_BIT * 4;  // threshold verifing correlation value
 
+      gr_complex corr_temp(0.0f,0.0f);
       float max_corr = 0.0f;
       int max_index = 0;
 
@@ -42,20 +59,14 @@ namespace gr
         standard_deviation = sqrt(standard_deviation);
 
         // calculate correlation value
-        float corr_candidates[2] = {0.0f};
-        for(int j=0 ; j<2*TAG_PREAMBLE_BITS ; j++)  // j: half_bit index of TAG_PREAMBLE
-        {
-          for(int k=0 ; k<(n_samples_TAG_BIT/2.0) ; k++)
-          {
-            for(int m=0 ; m<2 ; m++)  // m: index of TAG_PREAMBLE type
-              corr_candidates[m] += TAG_PREAMBLE[m][j] * ((ys->norm_in(i + j*(int)(n_samples_TAG_BIT/2.0) + k) - average_amp) / standard_deviation);
-          }
+        if(i==0){
+          corr_temp = mask_correlation(ys, TAG_PREAMBLE_MASKS, TAG_PREAMBLE_MASKS_LENGTH);
+        }else{
+          corr_temp = mask_shift_one_sample(ys,TAG_PREAMBLE_MASKS, TAG_PREAMBLE_MASKS_LENGTH, corr_temp, i-1);
         }
 
         // get max correlation value for ith start point
-        float corr = 0.0f;
-        for(int j=0 ; j<2 ; j++)
-          if(corr_candidates[j] > corr) corr = corr_candidates[j];
+        float corr = std::abs(corr_temp/standard_deviation);
 
         // compare with current max correlation value
         if(corr > max_corr)
@@ -78,45 +89,60 @@ namespace gr
       else return -1;
     }
 
+
     std::vector<float> tag_decoder_impl::tag_detection(sample_information* ys, int index, int n_expected_bit)
       // This method decodes n_expected_bit of data by using previous methods, and returns the vector of the decoded data.
       // index: start point of "data bit", do not decrease half bit!
     {
       std::vector<float> decoded_bits;
 
-      int mask_level = determine_first_mask_level(ys, index);
-      int complex_mask_level = -1;
+      int mask_level = 1;
       int shift = 0;
       double max_corr_sum = 0.0f;
       gr_complex max_complex_corr_sum(0.0, 0.0);
 
       for(int i=0 ; i<n_expected_bit ; i++)
       {
-        int idx = index + i*n_samples_TAG_BIT + shift;  // start point of decoding bit with shifting
-        float max_corr = 0.0f;
-        gr_complex max_complex_corr(0.0, 0.0);
-        int max_index;
+        int idx = index + i*n_samples_TAG_BIT + shift - n_samples_TAG_BIT/2;  // start point of decoding bit with shifting
+        std::complex<double> max_corr;
+        int max_bit;
         int curr_shift;
 
-        // shifting from idx-SHIFT_SIZE to idx+SHIFT_SIZE
-        for(int j=0 ; j<(SHIFT_SIZE*2 + 1) ; j++)
-        {
-          int index = decode_single_bit(ys, idx+j-SHIFT_SIZE, mask_level, complex_mask_level);
-          float corr = ys->corr();
 
-          if(corr > max_corr)
-          {
-            max_corr = corr;
-            max_index = index;
-            max_complex_corr = ys->complex_corr();
-            curr_shift = j - SHIFT_SIZE;  // find the best current shift value
+        //culculate left most shifted correlation value
+        std::vector<std::complex<double>> corr_result(2);
+        corr_result[0] = mask_correlation(ys, FM0_MASKS[0], FM0_MASKS_LENGTH,idx-SHIFT_SIZE, mask_level);
+        corr_result[1] = mask_correlation(ys, FM0_MASKS[1], FM0_MASKS_LENGTH,idx-SHIFT_SIZE, mask_level);
+        if(std::abs(corr_result[0]) > std::abs(corr_result[1])){
+          max_corr = corr_result[0];
+          max_bit = 0;
+        }else{
+          max_corr = corr_result[1];
+          max_bit = 1;
+        }
+        curr_shift = -2;
+
+
+        //calculate new corr value by shifting left to right one sample each
+        for(int j=-SHIFT_SIZE ; j<SHIFT_SIZE ; j++)
+        {
+          corr_result[0] = mask_shift_one_sample(ys, FM0_MASKS[0], FM0_MASKS_LENGTH, corr_result[0], idx+j, mask_level);
+          corr_result[1] = mask_shift_one_sample(ys, FM0_MASKS[1], FM0_MASKS_LENGTH, corr_result[1], idx+j, mask_level);
+
+          //Find the Biggest Correlation value
+          for(int k=0; k<=1; k++){
+            if(std::abs(corr_result[k]) > std::abs(max_corr)){
+              max_corr = corr_result[k];
+              max_bit = k;
+              curr_shift = j;
+            }
           }
         }
 
-        max_corr_sum += max_corr;
-        max_complex_corr_sum += max_complex_corr;
+        max_corr_sum += std::abs(max_corr);
+        max_complex_corr_sum += max_corr;
 
-        
+
 #ifdef __DEBUG__
         debug_log << "[" << i+1 << "th bit]\tcorr=";
         debug_log << std::left << std::setw(8) << max_corr;
@@ -127,12 +153,11 @@ namespace gr
         else debug_log << " (low start)" << std::endl;
 #endif
 
-        if(max_index){
+        if(max_bit == 1){
           mask_level *= -1; // change mask_level(start level of the next bit) when the decoded bit is 1
-          complex_mask_level *= -1;
         }
 
-        decoded_bits.push_back(max_index);
+        decoded_bits.push_back(max_bit);
         shift += curr_shift;  // update the shift value
       }
 
@@ -142,77 +167,43 @@ namespace gr
       return decoded_bits;
     }
 
-    int tag_decoder_impl::determine_first_mask_level(sample_information* ys, int index)
-      // This method searches whether the first bit starts with low level or high level.
-      // If the first bit starts with low level, it returns -1.
-      // If the first bit starts with high level, it returns 0.
-      // index: start point of "data bit", do not decrease half bit!
-    {
-      decode_single_bit(ys, index, -1, -1);
-      float low_level_corr = ys->corr();
 
-      decode_single_bit(ys, index, 1, 1);
-      if(low_level_corr > ys->corr()) return -1;
-      else return 1;
-    }
-
-    int tag_decoder_impl::decode_single_bit(sample_information* ys, int index, int mask_level, int complex_mask_level)
-      // This method decodes single bit and returns the decoded value and the correlation score.
-      // index: start point of "data bit", do not decrease half bit!
-      // mask_level: start level of "decoding bit". (-1)low level start, (1)high level start.
-    {
-      const float masks[2][2][4] = { // first, last elements are extra bits. second, third elements are real signal.
-        {{1, -1, 1, -1}, {1, -1, -1, 1}}, // low level start
-        {{-1, 1, -1, 1}, {-1, 1, 1, -1}}  // high level start
-      };
-
-      if(mask_level == -1) mask_level = 0;  // convert for indexing
-      if(complex_mask_level == -1) complex_mask_level = 0;  // convert for indexing
+    std::complex<double> tag_decoder_impl::mask_correlation(sample_information * ys, const float mask_data[],const int mask_length, int index, int mask_level){
+      std::vector<float> mask(mask_data, mask_data+mask_length-1);
+      
+      std::complex<double> result(0.0,0.0);
 
 
-      float max_corr = 0.0f;
-      gr_complex max_complex_corr(0.0, 0.0);
-      int max_index = -1;
-
-      float average_amp = 0.0f;
-      gr_complex average_complex_amp = std::complex<float>(0.0,0.0);
-      for(int j=-(n_samples_TAG_BIT*0.5) ; j<(n_samples_TAG_BIT*1.5) ; j++){
-        average_amp += ys->norm_in(index+j);
-        average_complex_amp += ys->in(index+j);
-      }
-      average_amp /= (2*n_samples_TAG_BIT);
-      average_complex_amp /= (2*n_samples_TAG_BIT);
-
-      // compare with two masks (0 or 1)
-      for(int i=0 ; i<2 ; i++)
-      {
-        float corr = 0.0f;
-        gr_complex complex_corr(0.0,0.0);
-        for(int j=-(n_samples_TAG_BIT*0.5) ; j<(n_samples_TAG_BIT*1.5) ; j++)
-        {
-          int idx;
-          if(j < 0) idx = 0;                            // first section (trailing half bit of the previous bit)
-          else if(j < (n_samples_TAG_BIT*0.5)) idx = 1; // second section (leading half bit of the data bit)
-          else if(j < n_samples_TAG_BIT) idx = 2;       // third section (trailing half bit of the data bit)
-          else idx = 3;                                 // forth section (leading half bit of the later bit)
-
-          //corr += masks[mask_level][i][idx] * std::sqrt(std::norm((ys->in(index+j) - average_complex_amp)));
-          corr += masks[mask_level][i][idx] * (ys->norm_in(index+j) - average_amp);
-          complex_corr += (masks[complex_mask_level][i][idx] * (ys->in(index+j) - average_complex_amp));
-        }
-        //corr = std::abs(corr);
-
-        if(corr > max_corr)
-        {
-          max_corr = corr;
-          max_index = i;
-          max_complex_corr = complex_corr;
+      for(int i_mask = 0; i_mask < mask_length; i_mask++){
+        for(int i_sam = (int)n_samples_TAG_BIT/2 * i_mask; i_sam < ((int)n_samples_TAG_BIT/2 * (i_mask + 1)); i_sam++){
+          result += (ys->in(index + i_sam) * mask[i_mask]);
         }
       }
 
-      ys->set_corr(max_corr/(2*n_samples_TAG_BIT));
-      ys->set_complex_corr(max_complex_corr/(2*n_samples_TAG_BIT));
-      return max_index;
+      result *= mask_level;
+
+      return result;
     }
-  }
-}
+
+    std::complex<double> tag_decoder_impl::mask_shift_one_sample(sample_information * ys, const float mask_data[], const int mask_length, std::complex<double> prev_result, int prev_index, int mask_level){
+      std::vector<float> mask(mask_data, mask_data+mask_length-1);
+
+      std::complex<double> result(0.0,0.0);
+
+      result -= ys->in(prev_index) * mask[0];
+      result += ys->in(prev_index + ((int)n_samples_TAG_BIT/2 * (mask_length))) * mask[mask_length - 1];
+
+      for(int i_mask = 1; i_mask < mask_length; i_mask++){
+        int i_sam = (int)n_samples_TAG_BIT/2 * i_mask;
+        result += (ys->in(prev_index + i_sam) * (mask[i_mask-1] - mask[i_mask]));
+      }
+
+      result *= mask_level;
+      result += prev_result;
+
+      return result;           
+    }
+
+
+  } //end of rfid
+} //end of gr

--- a/gr-rfid/lib/tag_decoder_impl.cc
+++ b/gr-rfid/lib/tag_decoder_impl.cc
@@ -123,6 +123,7 @@ namespace gr
           log << "│ Preamble detected!" << std::endl;
 #endif
 
+          
 
 #ifdef DEBUG_TAG_DECODER_IMPL_PREAMBLE
           debug_preamble(&ys, mode, current_round_slot, index);
@@ -190,9 +191,8 @@ namespace gr
 #endif
 
       std::cout << "RN16 decoded | ";
-      reader_state->gen2_logic_status = SEND_ACK;
-      
-      goto_next_slot();      
+      //reader_state->gen2_logic_status = SEND_ACK;
+      goto_next_slot();
    }
 
 
@@ -210,7 +210,7 @@ namespace gr
 
 #endif
 
-      for(int i=0 ; i<EPC_bits.size() ; i++)
+      for(unsigned int i=0 ; i<EPC_bits.size() ; i++)
       {
         char_bits[i] = EPC_bits[i] + '0';
 #ifdef __DEBUG_LOG__
@@ -290,7 +290,8 @@ namespace gr
       }
     }
 
-#ifdef DEBUG_TAG_DECODER_IMPL_INPUT
+#ifdef DEBUG_TAG_DECODER_
+    IMPL_INPUT
     void tag_decoder_impl::debug_input(sample_information* ys, int mode, std::string current_round_slot)
     {
       std::string path;
@@ -304,8 +305,7 @@ namespace gr
 
       for(int i=0 ; i<ys->total_size() ; i++)
       {
-        debug_i << ys->in(i).real() << " ";
-        debug_q << ys->in(i).imag() << " ";
+        debug << ys->in(i);
       }
 
       debug_i.close();
@@ -313,6 +313,7 @@ namespace gr
       debug.close();
     }
 #endif
+
 
 #ifdef DEBUG_TAG_DECODER_IMPL_PREAMBLE
     void tag_decoder_impl::debug_preamble(sample_information* ys, int mode, std::string current_round_slot, int index)
@@ -328,8 +329,7 @@ namespace gr
 
       for(int i=-n_samples_TAG_BIT*TAG_PREAMBLE_BITS ; i<0 ; i++)
       {
-        debug_i << ys->in(index+i).real() << " ";
-        debug_q << ys->in(index+i).imag() << " ";
+        debug << ys->in(i+index).real()<<","<<ys->in(i+index).imag()<<std::endl;
       }
 
       debug_i.close();
@@ -338,28 +338,29 @@ namespace gr
     }
 #endif
 
+
+
 #ifdef DEBUG_TAG_DECODER_IMPL_SAMPLE
-    void tag_decoder_impl::debug_sample(sample_information* ys, int mode, std::string current_round_slot, int index)
-    {
-      std::string path;
-      if(mode == 1) path = (debug_folder_path+"RN16_sample/"+current_round_slot).c_str();
-      else if(mode == 2) path = (debug_folder_path+"EPC_sample/"+current_round_slot).c_str();
-      else return;
-
-      std::ofstream debug_i((path+"_I").c_str(), std::ios::app);
-      std::ofstream debug_q((path+"_Q").c_str(), std::ios::app);
-      std::ofstream debug(path, std::ios::app);
-
-      for(int i=0 ; i<n_samples_TAG_BIT*(EPC_BITS-1) ; i++)
+      void tag_decoder_impl::debug_sample(sample_information* ys, int mode, std::string current_round_slot, int index)
       {
-        debug_i << ys->in(index+i).real() << " ";
-        debug_q << ys->in(index+i).imag() << " ";
-      }
+        std::string path;
+        if(mode == 1) path = (debug_folder_path+"RN16_sample/"+current_round_slot).c_str();
+        else if(mode == 2) path = (debug_folder_path+"EPC_sample/"+current_round_slot).c_str();
+        else return;
 
-      debug_i.close();
-      debug_q.close();
-      debug.close();
-    }
+        std::ofstream debug_i((path+"_I").c_str(), std::ios::app);
+        std::ofstream debug_q((path+"_Q").c_str(), std::ios::app);
+        std::ofstream debug(path, std::ios::app);
+
+        for(int i=0 ; i<n_samples_TAG_BIT*(RN16_BITS-1) ; i++)
+        {
+          debug << ys->in(i+index).real()<<","<<ys->in(i+index).imag()<<std::endl;
+        }
+
+        debug_i.close();
+        debug_q.close();
+        debug.close();
+      }
 #endif
 
     /* Function adapted from https://www.cgran.org/wiki/Gen2 */

--- a/gr-rfid/lib/tag_decoder_impl.cc
+++ b/gr-rfid/lib/tag_decoder_impl.cc
@@ -1,22 +1,22 @@
 /* -*- c++ -*- */
 /*
-* Copyright 2015 <Nikos Kargas (nkargas@isc.tuc.gr)>.
-*
-* This is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 3, or (at your option)
-* any later version.
-*
-* This software is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this software; see the file COPYING.  If not, write to
-* the Free Software Foundation, Inc., 51 Franklin Street,
-* Boston, MA 02110-1301, USA.
-*/
+ * Copyright 2015 <Nikos Kargas (nkargas@isc.tuc.gr)>.
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -29,6 +29,8 @@
 #include <cmath>
 #include <sys/time.h>
 #include "tag_decoder_impl.h"
+
+#define PREAMBLE_SEARCH_BIT_SIZE  (8)
 
 namespace gr
 {
@@ -52,6 +54,7 @@ namespace gr
     {
       char_bits = new char[128];
       n_samples_TAG_BIT = TPRI_D * s_rate / pow(10,6);
+      n_samples_T1  = T1_D * (sample_rate / pow(10,6));
     }
 
 
@@ -67,7 +70,7 @@ namespace gr
       ninput_items_required[0] = noutput_items;
     }
 
-
+    
 
 
 
@@ -76,8 +79,15 @@ namespace gr
       float* out = (float *)output_items[0];
       int consumed = 0;
 
+      if(!flag_preamble && (ninput_items[0] >= (n_samples_TAG_BIT * (TAG_PREAMBLE_BITS + PREAMBLE_SEARCH_BIT_SIZE))))
+      {
+        sample_information ys ((gr_complex*)input_items[0], ninput_items[0]);
+        index = tag_sync(&ys, PREAMBLE_SEARCH_BIT_SIZE);
+        flag_preamble = true;
+      }
+
       // Processing only after n_samples_to_ungate are available and we need to decode
-      if(ninput_items[0] >= reader_state->n_samples_to_ungate)
+      if(flag_preamble && (ninput_items[0] >= reader_state->n_samples_to_ungate))
       {
         int mode = -1;
         if(reader_state->decoder_status == DECODER_DECODE_RN16) mode = 1;
@@ -104,7 +114,6 @@ namespace gr
 #endif
 
         // detect preamble
-        int index;
         if(mode == 1) index = tag_sync(&ys, RN16_BITS-1);
         else if(mode == 2) index = tag_sync(&ys, EPC_BITS-1);
 
@@ -143,6 +152,7 @@ namespace gr
         // process for GNU RADIO
         produce(1, ninput_items[0]);
         consumed = reader_state->n_samples_to_ungate;
+        flag_preamble = false;
       }
 
       consume_each(consumed);
@@ -188,9 +198,8 @@ namespace gr
 #endif
 
       std::cout << "RN16 decoded | ";
-      //reader_state->gen2_logic_status = SEND_ACK;
-      goto_next_slot();
-   }
+      reader_state->gen2_logic_status = SEND_ACK;
+    }
 
 
 
@@ -199,9 +208,9 @@ namespace gr
       std::vector<float> EPC_bits = tag_detection(ys, index, EPC_BITS-1);  // EPC_BITS includes one dummy bit
 
       // convert EPC_bits from float to char in order to use Buettner's function
-     
+
 #ifdef __DEBUG_LOG__
-     
+
       log << "│ EPC=";
       debug_log << "EPC=";
 
@@ -289,26 +298,26 @@ namespace gr
 
 #ifdef DEBUG_TAG_DECODER_
     IMPL_INPUT
-    void tag_decoder_impl::debug_input(sample_information* ys, int mode, std::string current_round_slot)
-    {
-      std::string path;
-      if(mode == 1) path = (debug_folder_path+"RN16_input/"+current_round_slot).c_str();
-      else if(mode == 2) path = (debug_folder_path+"EPC_input/"+current_round_slot).c_str();
-      else return;
-
-      std::ofstream debug_i((path+"_I").c_str(), std::ios::app);
-      std::ofstream debug_q((path+"_Q").c_str(), std::ios::app);
-      std::ofstream debug(path, std::ios::app);
-
-      for(int i=0 ; i<ys->total_size() ; i++)
+      void tag_decoder_impl::debug_input(sample_information* ys, int mode, std::string current_round_slot)
       {
-        debug << ys->in(i);
-      }
+        std::string path;
+        if(mode == 1) path = (debug_folder_path+"RN16_input/"+current_round_slot).c_str();
+        else if(mode == 2) path = (debug_folder_path+"EPC_input/"+current_round_slot).c_str();
+        else return;
 
-      debug_i.close();
-      debug_q.close();
-      debug.close();
-    }
+        std::ofstream debug_i((path+"_I").c_str(), std::ios::app);
+        std::ofstream debug_q((path+"_Q").c_str(), std::ios::app);
+        std::ofstream debug(path, std::ios::app);
+
+        for(int i=0 ; i<ys->total_size() ; i++)
+        {
+          debug << ys->in(i);
+        }
+
+        debug_i.close();
+        debug_q.close();
+        debug.close();
+      }
 #endif
 
 
@@ -338,26 +347,26 @@ namespace gr
 
 
 #ifdef DEBUG_TAG_DECODER_IMPL_SAMPLE
-      void tag_decoder_impl::debug_sample(sample_information* ys, int mode, std::string current_round_slot, int index)
+    void tag_decoder_impl::debug_sample(sample_information* ys, int mode, std::string current_round_slot, int index)
+    {
+      std::string path;
+      if(mode == 1) path = (debug_folder_path+"RN16_sample/"+current_round_slot).c_str();
+      else if(mode == 2) path = (debug_folder_path+"EPC_sample/"+current_round_slot).c_str();
+      else return;
+
+      std::ofstream debug_i((path+"_I").c_str(), std::ios::app);
+      std::ofstream debug_q((path+"_Q").c_str(), std::ios::app);
+      std::ofstream debug(path, std::ios::app);
+
+      for(int i=0 ; i<n_samples_TAG_BIT*(RN16_BITS-1) ; i++)
       {
-        std::string path;
-        if(mode == 1) path = (debug_folder_path+"RN16_sample/"+current_round_slot).c_str();
-        else if(mode == 2) path = (debug_folder_path+"EPC_sample/"+current_round_slot).c_str();
-        else return;
-
-        std::ofstream debug_i((path+"_I").c_str(), std::ios::app);
-        std::ofstream debug_q((path+"_Q").c_str(), std::ios::app);
-        std::ofstream debug(path, std::ios::app);
-
-        for(int i=0 ; i<n_samples_TAG_BIT*(RN16_BITS-1) ; i++)
-        {
-          debug << ys->in(i+index).real()<<","<<ys->in(i+index).imag()<<std::endl;
-        }
-
-        debug_i.close();
-        debug_q.close();
-        debug.close();
+        debug << ys->in(i+index).real()<<","<<ys->in(i+index).imag()<<std::endl;
       }
+
+      debug_i.close();
+      debug_q.close();
+      debug.close();
+    }
 #endif
 
     /* Function adapted from https://www.cgran.org/wiki/Gen2 */

--- a/gr-rfid/lib/tag_decoder_impl.cc
+++ b/gr-rfid/lib/tag_decoder_impl.cc
@@ -82,7 +82,7 @@ namespace gr
       if(!flag_preamble && (ninput_items[0] >= (n_samples_TAG_BIT * (TAG_PREAMBLE_BITS + PREAMBLE_SEARCH_BIT_SIZE))))
       {
         sample_information ys ((gr_complex*)input_items[0], ninput_items[0]);
-        index = tag_sync(&ys, PREAMBLE_SEARCH_BIT_SIZE);
+        index = tag_sync(&ys);
         flag_preamble = true;
       }
 
@@ -112,10 +112,6 @@ namespace gr
 #ifdef DEBUG_TAG_DECODER_IMPL_INPUT
         debug_input(&ys, mode, current_round_slot);
 #endif
-
-        // detect preamble
-        if(mode == 1) index = tag_sync(&ys, RN16_BITS-1);
-        else if(mode == 2) index = tag_sync(&ys, EPC_BITS-1);
 
         if(index == -1)
         {

--- a/gr-rfid/lib/tag_decoder_impl.cc
+++ b/gr-rfid/lib/tag_decoder_impl.cc
@@ -123,8 +123,6 @@ namespace gr
           log << "│ Preamble detected!" << std::endl;
 #endif
 
-          
-
 #ifdef DEBUG_TAG_DECODER_IMPL_PREAMBLE
           debug_preamble(&ys, mode, current_round_slot, index);
 #endif
@@ -166,7 +164,6 @@ namespace gr
       for(int i=0 ; i<RN16_bits.size() ; i++)
       {
         out[written++] = RN16_bits[i];
-
 #ifdef __DEBUG_LOG__
         if(i % 4 == 0)
         {

--- a/gr-rfid/lib/tag_decoder_impl.cc
+++ b/gr-rfid/lib/tag_decoder_impl.cc
@@ -191,7 +191,8 @@ namespace gr
 #endif
 
       std::cout << "RN16 decoded | ";
-      reader_state->gen2_logic_status = SEND_ACK;
+ //     reader_state->gen2_logic_status = SEND_ACK;
+      goto_next_slot();
       
     }
 

--- a/gr-rfid/lib/tag_decoder_impl.cc
+++ b/gr-rfid/lib/tag_decoder_impl.cc
@@ -156,7 +156,6 @@ namespace gr
     {
       std::vector<float> RN16_bits = tag_detection(ys, index, RN16_BITS-1);  // RN16_BITS includes one dummy bit
 
-
 #ifdef __DEBUG_LOG__
       // write RN16_bits to the next block
       log << "│ RN16=";
@@ -193,7 +192,8 @@ namespace gr
       std::cout << "RN16 decoded | ";
       reader_state->gen2_logic_status = SEND_ACK;
       
-    }
+      goto_next_slot();      
+   }
 
 
 
@@ -202,7 +202,7 @@ namespace gr
       std::vector<float> EPC_bits = tag_detection(ys, index, EPC_BITS-1);  // EPC_BITS includes one dummy bit
 
       // convert EPC_bits from float to char in order to use Buettner's function
-
+     
 #ifdef __DEBUG_LOG__
      
       log << "│ EPC=";
@@ -306,7 +306,6 @@ namespace gr
       {
         debug_i << ys->in(i).real() << " ";
         debug_q << ys->in(i).imag() << " ";
-        debug << ys->norm_in(i) << " ";
       }
 
       debug_i.close();
@@ -331,7 +330,6 @@ namespace gr
       {
         debug_i << ys->in(index+i).real() << " ";
         debug_q << ys->in(index+i).imag() << " ";
-        debug << ys->norm_in(index+i) << " ";
       }
 
       debug_i.close();
@@ -356,7 +354,6 @@ namespace gr
       {
         debug_i << ys->in(index+i).real() << " ";
         debug_q << ys->in(index+i).imag() << " ";
-        debug << ys->norm_in(index+i) << " ";
       }
 
       debug_i.close();

--- a/gr-rfid/lib/tag_decoder_impl.h
+++ b/gr-rfid/lib/tag_decoder_impl.h
@@ -79,7 +79,7 @@ namespace gr
         int check_crc(char*, int);
 
         // tag_decoder_decoder.cc
-        int tag_sync(sample_information*, int);
+        int tag_sync(sample_information*);
         std::vector<float> tag_detection(sample_information*, int, int);
         int determine_first_mask_level(sample_information*, int);
         std::complex<double> mask_correlation(sample_information *, const float[], const int, int index = 0,int mask_level = 1);

--- a/gr-rfid/lib/tag_decoder_impl.h
+++ b/gr-rfid/lib/tag_decoder_impl.h
@@ -41,8 +41,12 @@ namespace gr
     {
       private:
         float n_samples_TAG_BIT;
+        int n_samples_T1;
         int s_rate;
         char * char_bits;
+        int index;
+
+        bool flag_preamble = false;
 
         class sample_information
         {

--- a/gr-rfid/lib/tag_decoder_impl.h
+++ b/gr-rfid/lib/tag_decoder_impl.h
@@ -31,9 +31,7 @@
 //#define DEBUG_TAG_DECODER_IMPL_INPUT
 //#define DEBUG_TAG_DECODER_IMPL_PREAMBLE
 //#define DEBUG_TAG_DECODER_IMPL_SAMPLE
-
-#define __DEBUG_LOG__
-
+//define __DEBUG_LOG__
 
 namespace gr
 {
@@ -51,8 +49,6 @@ namespace gr
           private:
             gr_complex* _in;
             int _total_size;
-            std::vector<float> _norm_in;
-
             float _corr;
             gr_complex _complex_corr;
 
@@ -82,7 +78,9 @@ namespace gr
         int tag_sync(sample_information*, int);
         std::vector<float> tag_detection(sample_information*, int, int);
         int determine_first_mask_level(sample_information*, int);
-        int decode_single_bit(sample_information* in, int, int, int);
+        std::complex<double> mask_correlation(sample_information *, const float[], const int, int index = 0,int mask_level = 1);
+        std::complex<double> mask_shift_one_sample(sample_information *, const float[], const int, std::complex<double>, int prev_index = 0, int mask_level = 1);
+
 
         // debug_message
         std::string current_round_slot;


### PR DESCRIPTION
기존 Shifting 메커니즘은 모든 sample을 다시 correlation을 통해 계산하는 방식으로 이뤄졌음

그러나 shift전후의 correlation계산에서는 중복되는 샘플이 대다수이며 일부 부분의 샘플만 변화함.

따라서 이전 correlation계산에서 해당 부분의 샘플들만 재계산후 shift된 correlation 값을 도출해냄.

주의 : 기존과는 많은 부분을 수정하였으므로 다르므로 merge할때 확인 요망.